### PR TITLE
Remove employee delete action from admin screen

### DIFF
--- a/src/main/resources/static/js/screens/admin.js
+++ b/src/main/resources/static/js/screens/admin.js
@@ -475,9 +475,9 @@ class AdminScreen {
 
         // パスワード強度チェックは撤廃
 
-        // 編集・退職処理・削除ボタン（イベント委譲）: アイコン<i>内クリックにも反応するようclosestを使用
+        // 編集・退職処理ボタン（イベント委譲）: アイコン<i>内クリックにも反応するようclosestを使用
         document.addEventListener('click', (e) => {
-            const btn = e.target.closest('.edit-employee-btn, .deactivate-employee-btn, .delete-employee-btn');
+            const btn = e.target.closest('.edit-employee-btn, .deactivate-employee-btn');
             if (!btn) return;
             if (btn.classList.contains('edit-employee-btn')) {
                 const employeeId = btn.getAttribute('data-employee-id');
@@ -485,9 +485,6 @@ class AdminScreen {
             } else if (btn.classList.contains('deactivate-employee-btn')) {
                 const employeeId = btn.getAttribute('data-employee-id');
                 this.deactivateEmployee(parseInt(employeeId));
-            } else if (btn.classList.contains('delete-employee-btn')) {
-                const employeeId = btn.getAttribute('data-employee-id');
-                this.deleteEmployee(parseInt(employeeId));
             }
         });
     }
@@ -640,18 +637,12 @@ class AdminScreen {
                    </button>`
                 : '';
 
-            // 削除ボタン（全社員に表示）
-            const deleteButton = `<button class="btn btn-sm btn-outline-danger me-1 delete-employee-btn" data-employee-id="${employee.employeeId}">
-                     <i class="fas fa-trash"></i> 削除
-                   </button>`;
-
             row.innerHTML = `
                 <td>${username}</td>
                 <td><span class="${statusClass}">${statusText}</span></td>
                 <td>
                     ${vacationAdjustButton}
                     ${deactivateButton}
-                    ${deleteButton}
                 </td>
             `;
             this.employeesTableBody.appendChild(row);


### PR DESCRIPTION
## Summary
- remove the delete button from the admin employee list UI
- drop the associated delegated click handler for the delete action

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7ceebf51c8331b4a03c9c000e5718

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the employee delete button from the admin employee list and drops the delegated click handler for delete actions.
> 
> - **Admin UI (frontend)**:
>   - **Employee list (`src/main/resources/static/js/screens/admin.js`)**:
>     - Remove rendering of `delete-employee-btn` in `displayEmployees`.
>     - Drop `.delete-employee-btn` from delegated click handler in `setupEmployeeEventListeners`.
>     - Update related comment text to reflect only edit/deactivate actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 216c2cac9f9a4f55f280f1d3d0b9c94e0b092807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->