### PR TITLE
Allow weekend-spanning vacation requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 server.log
 app.log
 
+# Node
+/node_modules/
+
 # Python
 __pycache__/
 *.pyc

--- a/src/main/resources/static/js/screens/vacation.js
+++ b/src/main/resources/static/js/screens/vacation.js
@@ -232,16 +232,9 @@ class VacationScreen {
             return false;
         }
 
-        // 土日祝の申請禁止
         const businessDayCount = this.countBusinessDaysInclusive(start, end);
         if (businessDayCount === 0) {
-            this.showAlert('土日祝日は有給申請できません', 'warning');
-            return false;
-        }
-
-        const invalidDates = this.collectNonBusinessDays(start, end);
-        if (invalidDates.length > 0) {
-            this.showAlert(`土日祝日は申請できません（対象: ${invalidDates.join(', ')}）`, 'warning');
+            this.showAlert('申請期間に平日が含まれていません', 'warning');
             return false;
         }
 
@@ -285,18 +278,6 @@ class VacationScreen {
             cursor.setDate(cursor.getDate() + 1);
         }
         return count;
-    }
-
-    collectNonBusinessDays(start, end) {
-        const invalid = [];
-        const cursor = new Date(start);
-        while (cursor <= end) {
-            if (!this.isBusinessDay(cursor)) {
-                invalid.push(`${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, '0')}-${String(cursor.getDate()).padStart(2, '0')}`);
-            }
-            cursor.setDate(cursor.getDate() + 1);
-        }
-        return invalid;
     }
 
     getRemainingDays() {

--- a/src/test/java/com/kintai/controller/CancellationControllerTest.java
+++ b/src/test/java/com/kintai/controller/CancellationControllerTest.java
@@ -208,13 +208,27 @@ class CancellationControllerTest {
     }
 
     @Test
-    void cannotCreateVacationRequestOnHoliday() {
+    void cannotCreateVacationRequestWithoutBusinessDay() {
         LocalDate sunday = LocalDate.of(2025, 9, 7);
         assertThatThrownBy(() ->
                 vacationService.createVacationRequest(
                         employee.getEmployeeId(), sunday, sunday, "休日申請"))
                 .isInstanceOf(VacationException.class)
-                .hasMessageContaining("土日祝日は有給申請できません");
+                .hasMessageContaining("申請期間に平日が含まれていません");
+    }
+
+    @Test
+    void canCreateVacationRequestIncludingWeekendCountsWeekdaysOnly() {
+        LocalDate start = LocalDate.of(2025, 9, 1); // 月曜日
+        LocalDate end = LocalDate.of(2025, 9, 14);  // 日曜日を含む
+
+        VacationRequestDto response = vacationService.createVacationRequest(
+                employee.getEmployeeId(), start, end, "長期休暇");
+
+        VacationRequestDto.VacationData data = (VacationRequestDto.VacationData) response.getData();
+        assertThat(data.getDays()).isEqualTo(10);
+        assertThat(data.getStartDate()).isEqualTo(start);
+        assertThat(data.getEndDate()).isEqualTo(end);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ensure vacation requests may span weekends by counting only business days on the backend
- adjust the vacation request form validation to allow weekend dates while requiring at least one business day
- cover the new behaviour with service-level tests and ignore local node dependencies

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d7f3cd5e388331ad37a595e0e44e60

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable vacation requests that span weekends while counting only weekdays, updating backend validation, frontend form checks, and tests accordingly.
> 
> - **Backend**:
>   - `VacationService#createVacationRequest`: allow ranges including weekends; require at least one business day (`calculateVacationDays`), and reject when weekday count ≤ 0.
>   - Remove `enforceBusinessDaysOnly` and related hard holiday rejection; keep overlap and remaining-days checks.
> - **Frontend**:
>   - `static/js/screens/vacation.js`: permit weekend dates in validation; require `businessDayCount > 0`; remove `collectNonBusinessDays` and related blocking messages.
> - **Tests**:
>   - `CancellationControllerTest`: update holiday error assertion/message; add test verifying weekend-spanning range counts only weekdays.
> - **Tooling**:
>   - `.gitignore`: add `node_modules/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30dfa77512142b7de6b114c408812bf6af009866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->