### PR TITLE
Restrict attendance calendars to 2025-2027 with updated holiday data

### DIFF
--- a/src/main/resources/static/js/utils/businessDay.js
+++ b/src/main/resources/static/js/utils/businessDay.js
@@ -74,6 +74,7 @@
 
         add(1, 1);   // 元日
         add(2, 11);  // 建国記念の日
+        add(2, 23);  // 天皇誕生日
         add(4, 29);  // 昭和の日
         add(5, 3);   // 憲法記念日
         add(5, 4);   // みどりの日
@@ -81,7 +82,7 @@
         add(8, 11);  // 山の日
         add(11, 3);  // 文化の日
         add(11, 23); // 勤労感謝の日
-        add(12, 23); // 旧天皇誕生日（互換目的）
+        // 旧天皇誕生日（12/23）は現行の祝日制度では対象外
 
         addNthMonday(base, year, 1, 2);  // 成人の日
         addNthMonday(base, year, 7, 3);  // 海の日
@@ -120,6 +121,11 @@
         },
         isBusinessDay(date) {
             return !this.isWeekend(date) && !this.isHoliday(date);
+        },
+        getHolidayListForYear(year) {
+            const holidays = Array.from(getHolidaysForYear(year));
+            holidays.sort();
+            return holidays;
         }
     };
 


### PR DESCRIPTION
## Summary
- constrain the attendance history dropdown and employee calendar navigation to the 2025-01 through 2027-12 window
- reuse BusinessDayUtils for accurate holiday detection, including the current Emperor's birthday and substitute/citizens holidays
- expose a sorted holiday list API for the UI and update navigation controls to disable outside the supported range

## Testing
- node -e "global.window = global; require('./src/main/resources/static/js/utils/businessDay.js'); console.log(window.BusinessDayUtils.getHolidayListForYear(2025)); console.log(window.BusinessDayUtils.getHolidayListForYear(2026)); console.log(window.BusinessDayUtils.getHolidayListForYear(2027));"

------
https://chatgpt.com/codex/tasks/task_e_68d7f62a8f1c8331934ff551a3503ec8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits calendar navigation and history selection to 2025-01–2027-12, delegates holiday detection to BusinessDayUtils, and disables navigation outside range.
> 
> - **Calendar (`screens/calendar.js`)**
>   - Restrict navigation to `2025-01`–`2027-12` with clamping (`CALENDAR_RANGE`, `clampYearMonth`, `updateNavigationState`).
>   - Disable prev/next/today buttons at range edges; avoid redundant reloads when unchanged.
>   - Replace local holiday logic: use `window.BusinessDayUtils.isHoliday()`/`getHolidayListForYear()`; remove manual calculations.
> - **History (`screens/history.js`)**
>   - Constrain month dropdown and state to `2025-01`–`2027-12` (`HISTORY_CALENDAR_RANGE`), normalize selection.
>   - Switch holiday checks to `BusinessDayUtils`; drop in-file holiday/substitute/citizens logic.
>   - Add month index/format helpers for range handling.
> - **Utils (`utils/businessDay.js`)**
>   - Update holiday set: add current Emperor’s birthday (`2/23`), remove old `12/23`.
>   - Expose `BusinessDayUtils.getHolidayListForYear(year)` (sorted).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95d5e070c2ea448fbc3484ffab01a83fff03d7a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->